### PR TITLE
Fix code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -25,7 +25,8 @@
     "node": "^22.9.0",
     "nodeman": "^1.1.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/Backend/src/routes/pyqs.route.js
+++ b/Backend/src/routes/pyqs.route.js
@@ -1,5 +1,6 @@
 import express from "express";
 import { Router } from "express";
+import RateLimit from "express-rate-limit";
 import { 
     createPYQ, 
     getPYQ, 
@@ -11,10 +12,16 @@ import {upload} from '../middlewares/multer.middleware.js';
 
 const router = Router();
 
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
 router.post('/create',upload.single("questionPaper"), createPYQ);
 router.get('/', getPYQ);
 router.patch('/:pyqId/update',upload.single("questionPaper"), updatePYQ);
-router.get('/:pyqId/download', downloadPYQ);
+router.get('/:pyqId/download', limiter, downloadPYQ);
 
 export default router
 


### PR DESCRIPTION
Fixes [https://github.com/Sourish-Kanna/Libray-Website/security/code-scanning/6](https://github.com/Sourish-Kanna/Libray-Website/security/code-scanning/6)

To fix the problem, we need to introduce rate limiting to the Express application. This can be achieved by using the `express-rate-limit` package. We will set up a rate limiter that restricts the number of requests a client can make to the `/download` endpoint within a specified time window. This will help prevent abuse and protect the server from being overwhelmed by too many requests.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `Backend/src/routes/pyqs.route.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum 100 requests per 15 minutes).
4. Apply the rate limiter to the `/download` endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
