### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -25,7 +25,8 @@
     "node": "^22.9.0",
     "nodeman": "^1.1.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/Backend/src/routes/pyqs.route.js
+++ b/Backend/src/routes/pyqs.route.js
@@ -1,5 +1,6 @@
 import express from "express";
 import { Router } from "express";
+import RateLimit from "express-rate-limit";
 import { 
     createPYQ, 
     getPYQ, 
@@ -10,6 +11,13 @@ import {upload} from '../middlewares/multer.middleware.js';
 // import {verifyJWT} from '../middlewares/auth.middleware.js';
 
 const router = Router();
+
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
+router.use(limiter);
 
 router.post('/create',upload.single("questionPaper"), createPYQ);
 router.get('/', getPYQ);


### PR DESCRIPTION
Fixes [https://github.com/Sourish-Kanna/Libray-Website/security/code-scanning/5](https://github.com/Sourish-Kanna/Libray-Website/security/code-scanning/5)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set up a rate limiter and apply it to the routes. This will ensure that the application is protected against denial-of-service attacks by limiting the number of requests a client can make within a specified time window.

We will:
1. Install the `express-rate-limit` package.
2. Import the package in the file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the routes that need protection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
